### PR TITLE
Fix overlapping task state and table

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+backend/test

--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/frontend/.editorconfig
+++ b/frontend/.editorconfig
@@ -2,7 +2,7 @@
 root = true
 
 [*]
-indent_style = space
+indent_style = tab
 indent_size = 2
 end_of_line = lf
 charset = utf-8

--- a/frontend/components/TaskList.vue
+++ b/frontend/components/TaskList.vue
@@ -8,7 +8,8 @@
 		/>
 		<TaskDialog v-model="showTaskDialog" :task="currentTask" />
 
-		<v-btn-toggle v-model="status" mandatory background-color="rgba(0, 0, 0, 0)">
+		<v-row class="px-4 pt-4">
+			<v-btn-toggle v-model="status" mandatory background-color="rgba(0, 0, 0, 0)">
 			<v-row class="pa-3">
 				<v-btn
 					v-for="st in allStatus"
@@ -34,7 +35,9 @@
 				</v-btn>
 			</v-row>
 		</v-btn-toggle>
+  </v-row>
 
+  <v-row class="px-4 pt-4">
 		<v-data-table
 			:items="classifiedTasks[status]"
 			:headers="headers"
@@ -43,6 +46,7 @@
 			:item-class="rowClass"
 			v-model="selected"
 			class="elevation-1"
+			style="width: 100%"
 		>
 			<template v-slot:top>
 				<v-row class="px-4">
@@ -176,7 +180,8 @@
 				</v-icon>
 			</template>
 		</v-data-table>
-	</div>
+  </v-row>
+  </div>
 </template>
 
 <script lang="ts">


### PR DESCRIPTION
The task state chooser (_pending, waiting, ..._) and the task table overlapped, which are moved to separate rows.

Plus two minor things:
* `backend/.gitignore` and `.dockerignore` files are added
* `.editorconfig` is updated to reflect tabs being used

Before:
![image](https://user-images.githubusercontent.com/58879/164648448-7f6f3a45-994d-4632-ab6f-13cb88f0e28d.png)

After:
![image](https://user-images.githubusercontent.com/58879/164647929-a106e032-4152-4adc-a70c-509492b647aa.png)
