### PR TITLE
Allow overriding TASKRC/TASKDATA using environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Then install nginx or other web servers
 to server frontend and proxy requests to backend
 (you can refer to `nginx/nginx.conf`).
 
+### Configuration
+
+The following environment variable may be set:
+ * `TASKRC` - the location of the `.taskrc` file, `/.taskrc` by default when run in _production_ mode
+ * `TASKDATA` - the location of the `.task` directory, `/.task` by default when run in _production_ mode
+
 
 ## Development
 

--- a/backend/src/taskwarrior.ts
+++ b/backend/src/taskwarrior.ts
@@ -2,10 +2,9 @@ import { TaskwarriorLib } from 'taskwarrior-lib';
 import * as path from 'path';
 
 const prod = process.env.NODE_ENV === 'production';
+const taskRc = process.env.TASKRC || (prod ? '/.taskrc' : path.join(__dirname, '../test/.taskrc'));
+const taskData = process.env.TASKDATA || (prod ? '/.task' : path.join(__dirname, '../test/.task'));
 
-const taskwarrior = new TaskwarriorLib(
-	prod ? '/.taskrc' : path.join(__dirname, '../test/.taskrc'),
-	prod ? '/.task' : path.join(__dirname, '../test/.task'),
-);
+const taskwarrior = new TaskwarriorLib(taskRc, taskData);
 
 export default taskwarrior;


### PR DESCRIPTION
`TASKRC`/`TASKDATA` environment variables are added to allow configuring the location when running the application. The existing defaults are kept as-is.