### PR TITLE
Compact task dialog fields

### DIFF
--- a/frontend/components/TaskDialog.vue
+++ b/frontend/components/TaskDialog.vue
@@ -24,24 +24,6 @@
 						hide-selected
 						label="Project"
 					/>
-					<v-text-field
-						v-model="formData.scheduled"
-						label="Scheduled"
-					/>
-					<v-text-field
-						v-model="formData.due"
-						:label="recur ? 'Due*' : 'Due'"
-						:rules="recur ? requiredRules : []"
-						:required="recur"
-					/>
-					<v-text-field
-						v-model="formData.wait"
-						label="Wait"
-					/>
-					<v-text-field
-						v-model="formData.until"
-						label="Until"
-					/>
 					<v-combobox
 						v-model="formData.tags"
 						:items="tags"
@@ -51,6 +33,40 @@
 						label="Tags"
 						hint="Press tab or enter to add new tags"
 					/>
+					<v-row class="px-3">
+						<v-text-field
+							class="mr-3"
+							v-model="formData.due"
+							:label="recur ? 'Due*' : 'Due'"
+							:rules="recur ? requiredRules : []"
+							:required="recur"
+						/>
+						<v-text-field
+							v-model="formData.until"
+							label="Until"
+						/>
+					</v-row>
+					<v-row class="px-3">
+						<v-text-field
+							class="mr-3"
+							v-model="formData.scheduled"
+							label="Scheduled"
+						/>
+						<v-text-field
+							v-model="formData.wait"
+							label="Wait"
+						/>
+					</v-row>
+					<v-row class="px-3">
+						<v-checkbox v-model="recur" class="mr-3" label="Recur" />
+						<v-text-field
+							label="period*"
+							v-model="formData.recur"
+							:rules="recur ? requiredRules : []"
+							:required="recur"
+							:disabled="!recur"
+						/>
+					</v-row>
 					<v-radio-group v-model="formData.priority" row hide-details class="align-center">
 						<template v-slot:prepend>
 							<span class="mr-3 subtitle-1">
@@ -64,16 +80,6 @@
 							:value="p.value"
 						/>
 					</v-radio-group>
-					<v-row class="px-3">
-						<v-checkbox v-model="recur" class="mr-3" label="Recur" />
-						<v-text-field
-							label="period*"
-							v-model="formData.recur"
-							:rules="recur ? requiredRules : []"
-							:required="recur"
-							:disabled="!recur"
-						/>
-					</v-row>
 
 					<v-list subheader dense flat>
 						<v-subheader>Annotations</v-subheader>


### PR DESCRIPTION
The task editing dialog could get a bit long with the new fields. The fields are rearranged, so that the shorter date fields may be in the same row on wider screens. On narrower screens the existing one-field-per-row is preserved.

Before:
![image](https://user-images.githubusercontent.com/58879/169685477-cc59130e-8842-4cad-9ced-d25cdaa45297.png)

After:
![image](https://user-images.githubusercontent.com/58879/169685510-feb0c690-e1b5-43b7-af42-b51263a846c4.png)
