### PR TITLE
Sorting urgent by most urgent first

### DIFF
--- a/frontend/components/TaskList.vue
+++ b/frontend/components/TaskList.vue
@@ -289,7 +289,7 @@ export default defineComponent({
 				: [{ text: 'Wait', value: 'wait' }]),
 			{ text: 'Until', value: 'until' },
 			{ text: 'Tags', value: 'tags' },
-			{ text: 'Urgency', value: 'urgency' },
+			{ text: 'Urgency', value: 'urgency', sort: (a: number, b: number) => !(a > b) },
 			{ text: 'Actions', value: 'actions', sortable: false }
 		]);
 


### PR DESCRIPTION
Minor thing, but clicking on the urgency field sorts by least urgent first, this is kind of unexpected behavior.

This PR changes the behavior to sorting by most urgent first.