### PR TITLE
Fixed sorting of urgency

### DIFF
--- a/frontend/components/TaskList.vue
+++ b/frontend/components/TaskList.vue
@@ -300,7 +300,7 @@ export default defineComponent({
 				: [{ text: 'Wait', value: 'wait' }]),
 			{ text: 'Until', value: 'until' },
 			{ text: 'Tags', value: 'tags' },
-			{ text: 'Urgency', value: 'urgency', sort: (a: number, b: number) => !(a > b) },
+			{ text: 'Urgency', value: 'urgency', sort: (a: number, b: number) => b - a },
 			{ text: 'Actions', value: 'actions', sortable: false }
 		]);
 


### PR DESCRIPTION
The `sort` function in the `headers` requires a number to be returned, instead of a boolean, just like the built-in sort function in arrays actually.

For my firefox browser, it actually also seemed to work by returning a boolean, but now I also tested it on my mobile chrome, where it was broken before, it works there now too.

I am very sorry for the previously broken commit, should fix #68