### PR TITLE
Add Manual "Sync" Button for Immediate Task Synchronization

### DIFF
--- a/frontend/components/TaskList.vue
+++ b/frontend/components/TaskList.vue
@@ -101,6 +101,18 @@
 						>
 							<v-icon>mdi-refresh</v-icon>
 						</v-btn>
+
+						<v-btn
+								v-if="showSyncBtn"
+								class="green ml-1"
+								fab
+								dark
+								title="Sync Tasks"
+								@click="syncTasks"
+							>
+								<v-icon>mdi-sync</v-icon>
+						</v-btn>
+
 						<v-btn
 							class="primary ml-1"
 							fab
@@ -341,6 +353,26 @@ export default defineComponent({
 
 		const showTaskDialog = ref(false);
 		const currentTask: Ref<Task | null> = ref(null);
+
+		const showSyncBtn = computed(() => {
+			return store.state.settings.autoSync !== '0';
+		});
+
+		const syncTasks = async () => {
+			try {
+				await store.dispatch('syncTasks');
+				store.commit('setNotification', {
+					color: 'success',
+					text: 'Successfully synced tasks.'
+				});
+			} catch (error) {
+				store.commit('setNotification', {
+					color: 'error',
+					text: 'Failed to sync tasks.'
+				});
+			}
+		};
+
 		const newTask = () => {
 			showTaskDialog.value = true;
 			currentTask.value = null;
@@ -416,6 +448,8 @@ export default defineComponent({
 			allStatus,
 			statusIcons,
 			selected,
+			showSyncBtn,
+			syncTasks,
 			newTask,
 			currentTask,
 			editTask,


### PR DESCRIPTION
**Description**:

This PR introduces a manual "Sync" button, allowing users to instigate immediate task synchronization.

**Related Issue**:
[Issue #78](https://github.com/DCsunset/taskwarrior-webui/issues/78)

**Key Points**:
- 🚀 New feature: Manual synchronization button.
- 🛠 Button is displayed if 'autosync' is enabled.
- 🤖 Tailored to enhance user experience across multiple taskwarrior clients.

**Reasoning**:

Having the auto-sync functionality with a specific interval is practical. Yet, there are instances where a user would want immediate synchronization, especially when transitioning between Taskwarrior clients:
- Switching from GUI to CLI.
- Transitioning between desktop and mobile devices.

The manual sync button ensures that the latest tasks are available across all clients without unnecessary waiting.

**Changes**:
- Introduced a "Sync" button that surfaces when 'autosync' is activated.
- Button prompts an on-the-spot sync operation.

**Future Considerations**:
- Pondering over a separate configuration toggle for this button to avoid conflating with the 'autosync' feature.

**Additional Info**:

Developed this enhancement to cater to a personal use-case. Although the contribution guidelines recommend opening an issue prior to a PR, I proceeded since the feature was already fleshed out and tested.

Eager to hear your feedback and iterate accordingly!