### PR TITLE
docs(README): fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ you may want to mount files to the same paths in the container using the followi
 
 ```sh
 docker run -d -p 8080:80 --name taskwarrior-webui \
-	-e TAKSRC=$HOME/.taskrc -e TASKDATA=$HOME/.task \
+	-e TASKRC=$HOME/.taskrc -e TASKDATA=$HOME/.task \
 	-v $HOME/.taskrc:$HOME/.taskrc -v $HOME/.task:$HOME/.task \
 	dcsunset/taskwarrior-webui
 ```


### PR DESCRIPTION
The docker deployment example with customized taskdata and taskrc path in RADME contains a typo that uses `TAKSRC` instead of correct `TASKRC`, which prevent the container from being properly configured.

This PR will fix it by changing `TAKSRC` into `TASKRC`.