### PR TITLE
Update Dockerfile to change apk repositories to v3.20/main and edge/community

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:latest
 
-RUN echo "http://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/v3.20/main" > /etc/apk/repositories
+RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN apk --no-cache add nodejs npm nginx task3 python3 build-base
 
 COPY ./frontend /src/frontend


### PR DESCRIPTION
Updates to alpine repositories to support the latest version of TaskWarrior 3.3.0 which is only available in edge/community at this time.