### PR TITLE
feat(frontend): add client-side text search for tasks

### DIFF
--- a/frontend/components/TaskList.vue
+++ b/frontend/components/TaskList.vue
@@ -8,7 +8,7 @@
 		/>
 		<TaskDialog v-model="showTaskDialog" :task="currentTask || undefined" />
 		<ColumnDialog v-model="showColumnDialog" :active-columns="headers"/>
-		<v-row class="px-4 pt-4">
+		<v-row class="px-4 pt-4 align-center">
 			<v-btn-toggle v-model="status" mandatory background-color="rgba(0, 0, 0, 0)">
 			<v-row class="pa-3">
 				<v-btn
@@ -35,6 +35,19 @@
 				</v-btn>
 			</v-row>
 		</v-btn-toggle>
+		<v-spacer />
+		<v-text-field
+			v-model="search"
+			prepend-inner-icon="mdi-magnify"
+			placeholder="Buscar tareas…"
+			outlined
+			dense
+			clearable
+			hide-details
+			single-line
+			style="max-width: 320px"
+			class="mr-4"
+		/>
   </v-row>
 
   <v-row class="px-4 pt-4">
@@ -89,18 +102,6 @@
 					</div>
 
 					<v-spacer />
-
-					<div class="ma-2" style="max-width: 320px; flex: 0 1 320px;">
-						<v-text-field
-							v-model="search"
-							prepend-inner-icon="mdi-magnify"
-							label="Search"
-							clearable
-							hide-details
-							dense
-							single-line
-						/>
-					</div>
 
 					<!-- Global Actions -->
 					<div class="ma-2">

--- a/frontend/components/TaskList.vue
+++ b/frontend/components/TaskList.vue
@@ -36,7 +36,18 @@
 			</v-row>
 		</v-btn-toggle>
 		<v-spacer />
+		<v-btn
+			v-if="!searchOpen"
+			icon
+			class="mr-4"
+			title="Buscar (/)"
+			@click="openSearch"
+		>
+			<v-icon>mdi-magnify</v-icon>
+		</v-btn>
 		<v-text-field
+			v-else
+			ref="searchInput"
 			v-model="search"
 			prepend-inner-icon="mdi-magnify"
 			placeholder="Buscar tareas…"
@@ -47,6 +58,8 @@
 			single-line
 			style="max-width: 320px"
 			class="mr-4"
+			@blur="handleSearchBlur"
+			@keydown.esc="closeSearch"
 		/>
   </v-row>
 
@@ -223,7 +236,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, useStore, computed, reactive, ref, watch, ComputedRef, Ref } from '@nuxtjs/composition-api';
+import { defineComponent, useStore, computed, reactive, ref, watch, nextTick, onMounted, onBeforeUnmount, ComputedRef, Ref } from '@nuxtjs/composition-api';
 import { Task } from 'taskwarrior-lib';
 import _ from 'lodash';
 import TaskDialog from '../components/TaskDialog.vue';
@@ -336,10 +349,40 @@ export default defineComponent({
 		const showColumnDialog = ref(false);
 
 		const search = ref('');
+		const searchOpen = ref(false);
+		const searchInput: Ref<any> = ref(null);
 
 		watch(search, () => {
 			selected.value = [];
 		});
+
+		const openSearch = async () => {
+			searchOpen.value = true;
+			await nextTick();
+			searchInput.value?.focus();
+		};
+
+		const closeSearch = () => {
+			search.value = '';
+			searchOpen.value = false;
+		};
+
+		const handleSearchBlur = () => {
+			if (!search.value) {
+				searchOpen.value = false;
+			}
+		};
+
+		const onGlobalKeydown = (e: KeyboardEvent) => {
+			if (e.key !== '/') return;
+			const t = e.target as HTMLElement | null;
+			if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+			e.preventDefault();
+			openSearch();
+		};
+
+		onMounted(() => window.addEventListener('keydown', onGlobalKeydown));
+		onBeforeUnmount(() => window.removeEventListener('keydown', onGlobalKeydown));
 
 		const matchesSearch = (task: Task, q: string) => {
 			if (!q) return true;
@@ -491,6 +534,11 @@ export default defineComponent({
 			showConfirmationDialog,
 			showColumnDialog,
 			search,
+			searchOpen,
+			searchInput,
+			openSearch,
+			closeSearch,
+			handleSearchBlur,
 			confirmation,
 			displayDate,
 			rowClass,

--- a/frontend/components/TaskList.vue
+++ b/frontend/components/TaskList.vue
@@ -90,6 +90,18 @@
 
 					<v-spacer />
 
+					<div class="ma-2" style="max-width: 320px; flex: 0 1 320px;">
+						<v-text-field
+							v-model="search"
+							prepend-inner-icon="mdi-magnify"
+							label="Search"
+							clearable
+							hide-details
+							dense
+							single-line
+						/>
+					</div>
+
 					<!-- Global Actions -->
 					<div class="ma-2">
 						<v-btn
@@ -210,7 +222,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, useStore, computed, reactive, ref, ComputedRef, Ref } from '@nuxtjs/composition-api';
+import { defineComponent, useStore, computed, reactive, ref, watch, ComputedRef, Ref } from '@nuxtjs/composition-api';
 import { Task } from 'taskwarrior-lib';
 import _ from 'lodash';
 import TaskDialog from '../components/TaskDialog.vue';
@@ -322,21 +334,39 @@ export default defineComponent({
 
 		const showColumnDialog = ref(false);
 
+		const search = ref('');
+
+		watch(search, () => {
+			selected.value = [];
+		});
+
+		const matchesSearch = (task: Task, q: string) => {
+			if (!q) return true;
+			const needle = q.toLowerCase();
+			if (task.description?.toLowerCase().includes(needle)) return true;
+			if (task.project?.toLowerCase().includes(needle)) return true;
+			if (task.tags?.some(t => t.toLowerCase().includes(needle))) return true;
+			if (task.annotations?.some(a => a.description?.toLowerCase().includes(needle))) return true;
+			return false;
+		};
+
 		const tempTasks: { [key: string]: ComputedRef<Task[]> } = {};
 		for (const status of allStatus) {
-			tempTasks[status] = computed((): Task[] => props.tasks?.filter(task => {
-				if (status === "waiting" || status === "pending") {
-					const waiting = (task.wait && !expiredDate(task.wait))
-						|| (task.scheduled && futureDate(task.scheduled));
-					return task.status === "pending" && (status === "pending" ? !waiting : waiting);
-				}
-				else if (status === "pending") {
-					return task.status === "pending" && !(task.wait && !expiredDate(task.wait));
-				}
-				else {
-					return task.status === status;
-				}
-			}));
+			tempTasks[status] = computed((): Task[] => {
+				const q = search.value || '';
+				return props.tasks?.filter(task => {
+					let passStatus: boolean;
+					if (status === "waiting" || status === "pending") {
+						const waiting = (task.wait && !expiredDate(task.wait))
+							|| (task.scheduled && futureDate(task.scheduled));
+						passStatus = task.status === "pending" && (status === "pending" ? !waiting : !!waiting);
+					}
+					else {
+						passStatus = task.status === status;
+					}
+					return passStatus && matchesSearch(task, q);
+				});
+			});
 		}
 		const classifiedTasks = reactive(tempTasks);
 
@@ -459,6 +489,7 @@ export default defineComponent({
 			showTaskDialog,
 			showConfirmationDialog,
 			showColumnDialog,
+			search,
 			confirmation,
 			displayDate,
 			rowClass,

--- a/frontend/components/TaskList.vue
+++ b/frontend/components/TaskList.vue
@@ -40,7 +40,7 @@
 			v-if="!searchOpen"
 			icon
 			class="mr-4"
-			title="Buscar (/)"
+			title="Buscar (/ o Ctrl+K)"
 			@click="openSearch"
 		>
 			<v-icon>mdi-magnify</v-icon>
@@ -374,9 +374,13 @@ export default defineComponent({
 		};
 
 		const onGlobalKeydown = (e: KeyboardEvent) => {
-			if (e.key !== '/') return;
-			const t = e.target as HTMLElement | null;
-			if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+			const isCtrlK = (e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'k';
+			const isSlash = e.key === '/';
+			if (!isCtrlK && !isSlash) return;
+			if (isSlash) {
+				const t = e.target as HTMLElement | null;
+				if (t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable)) return;
+			}
 			e.preventDefault();
 			openSearch();
 		};


### PR DESCRIPTION
Relates to #71.

This PR adds a lightweight text search field to the task list, covering the common "find tasks mentioning X" use case.

## What's included

- Case-insensitive substring search across `description`, `project`, `tags`, and `annotations`.
- Expand-on-click magnifier icon in the status-tabs row (keeps the default view uncluttered).
- Keyboard shortcuts:
  - `/` — focus search (ignored when typing in other inputs, so it doesn't interfere with the new-task dialog, etc.)
  - `Ctrl+K` / `Cmd+K` — focus search from anywhere, including inside inputs
  - `Esc` — close and clear
- Blur while empty auto-closes the input; blur with a value keeps it open so the user doesn't lose their filter context.
- Filters within the currently selected status tab (`pending`, `waiting`, `completed`, `deleted`, `recurring`).
- Changing the search term clears the current row selection (to avoid batch-acting on hidden rows), mirroring the existing behavior on tab switch.

## What's deliberately out of scope

I wanted to keep this PR narrow and leave room for discussion on the shape of more advanced modes. Happy to follow up with any of these if you'd prefer them in this PR instead:

- **Regex mode** matching Taskwarrior's own `task /expression/` syntax (the example in #71). Could be added behind a `.*` toggle inside the input to keep the default UX accessible to non-regex users.
- **Native Taskwarrior filters** (e.g. `project:Home status:pending due.before:eow`) passed through to the backend via `task <filter>`. This would require a backend endpoint and moves search off the client.
- **Server-side / CLI-backed search** in general — useful for very large task sets, but not needed for the common case.

## Notes on the approach

- Client-side only. No backend changes, no new dependencies, no schema changes, no new settings keys. The search state lives in component scope (not in Vuex / localStorage).
- Tasks are already loaded into `store.state.tasks` on navigation, so filtering happens against the in-memory array — instant response, works offline.
- I did not touch the lint baseline; the file had pre-existing style warnings/errors that are unchanged by this PR.

## Context on the issue

Issue #71 has been open since 2023-05-29 with no prior PR addressing it, which is why I'm opening this directly rather than starting a discussion on the issue first. If you'd prefer a different shape (regex by default, CLI passthrough, different UI placement), I'm happy to iterate — just let me know and I'll rework the branch.