### PR TITLE
fix(frontend): refresh task list after sync

### DIFF
--- a/frontend/store/index.ts
+++ b/frontend/store/index.ts
@@ -94,8 +94,9 @@ export const actions: ActionTree<RootState, RootState> = {
 		await context.dispatch('fetchTasks');
 	},
 
-	async syncTasks(_context) {
+	async syncTasks(context) {
 		await this.$axios.$post('/api/sync');
+		await context.dispatch('fetchTasks');
 	}
 };
 


### PR DESCRIPTION
## Summary

`syncTasks` in the Vuex store posts to `/api/sync` but does not refetch the task list afterwards, so the in-memory state stays stale until the user reloads the page. Any change pulled in by `task sync` (added, modified, or deleted tasks from another device) is invisible in the UI until F5.

This PR aligns `syncTasks` with the existing pattern used by `deleteTasks` and `updateTasks` — dispatch `fetchTasks` once the write completes.

## Change

```diff
-async syncTasks(_context) {
+async syncTasks(context) {
     await this.\$axios.\$post('/api/sync');
+    await context.dispatch('fetchTasks');
 }
```

## Test plan

- [x] Trigger a sync from the sync icon in the toolbar — tasks refresh without a manual reload.
- [x] Add/modify/delete a task on another device, run sync from the UI — the change appears immediately.
- [x] Behaviour of `deleteTasks` / `updateTasks` unchanged (they already did this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)